### PR TITLE
FACTOR8 - Modificação para rodar o comando docker-compose up

### DIFF
--- a/factor8/docker-compose.yml
+++ b/factor8/docker-compose.yml
@@ -2,9 +2,9 @@ version: "2"
 
 
 services:
-  lb:
-    container_name: lb
-    build: lb
+  web:
+    container_name: web
+    build: web
     restart: unless-stopped
     networks:
       - backend
@@ -22,7 +22,7 @@ services:
     expose:
       - 80
     depends_on:
-      - lb
+      - web
 
 networks:
   backend:


### PR DESCRIPTION
Substituição da referência lb por web a fim de manter a referência para a pasta web e de tornar o comando `docker-compose up -d` funcional, de acordo com o explicitado no capítulo **Concorrência**. 